### PR TITLE
strings with escape chars should be raw

### DIFF
--- a/tests/test_cfn_lint.py
+++ b/tests/test_cfn_lint.py
@@ -62,7 +62,7 @@ test_cases = [
             }
         },
         "templates": {
-            "test1": """{
+            "test1": r"""{
     "Parameters": {
         "BadJson": {
             "AllowedPattern": "\/"

--- a/tests/test_template_params.py
+++ b/tests/test_template_params.py
@@ -169,7 +169,7 @@ class TestParamGen(unittest.TestCase):
         genpassword_criteria = [
             # A tuple of (func_call, length, flags, re.Pattern, description)
             (pg.genpassword, 15, None, re.compile('[0-9A-Za-z]'), 'Testing a 15 character password. Default PW type'),
-            (pg.genpassword, 15, 'S', re.compile("[!#\$&{\*:\[=,\]-_%@\+a-zA-Z0-9]+"), 'Testing a 15 character password, Special Characters Type'),
+            (pg.genpassword, 15, 'S', re.compile(r"[!#\$&{\*:\[=,\]-_%@\+a-zA-Z0-9]+"), 'Testing a 15 character password, Special Characters Type'),
             (pg.genpassword, 15, 'A', re.compile('[0-9A-Za-z]'), 'Testing a 15 character password, Alphanumeric Character Type')
         ]
         for func_call, pwlen, pwflags, re_pattern, test_desc in genpassword_criteria:


### PR DESCRIPTION
fixes warnings in pytest output