### PR TITLE
AZ excludes

### DIFF
--- a/taskcat/cfg/schema_definitions.json
+++ b/taskcat/cfg/schema_definitions.json
@@ -18,6 +18,9 @@
                 "regions": {
                     "$ref": "#/definitions/regions"
                 },
+                "az_blacklist": {
+                    "$ref": "#/definitions/az_blacklist"
+                },
                 "package_lambda": {
                     "type": "boolean"
                 },
@@ -76,6 +79,15 @@
             "required": [
                 "template_file"
             ]
+        },
+        "az_blacklist": {
+            "$id": "#az_backlist",
+            "type": "array",
+            "uniqueItems": true,
+            "patternProperties": {
+                "type": "string",
+                "pattern": "^(ap|eu|us|sa|ca|cn|af|me)(n|s|e|w|c|ne|se|nw|sw)[0-9]-az[0-9]$"
+            }
         },
         "tests": {
             "$id": "#tests",

--- a/tests/test_template_params.py
+++ b/tests/test_template_params.py
@@ -30,36 +30,42 @@ class MockSingleAZClient:
                     "Messages": [],
                     "RegionName": "us-east-1",
                     "ZoneName": "us-east-1a",
+                    "ZoneId": "use1-az6",
                 },
                 {
                     "State": "available",
                     "Messages": [],
                     "RegionName": "us-east-1",
                     "ZoneName": "us-east-1b",
+                    "ZoneId": "use1-az5",
                 },
                 {
                     "State": "available",
                     "Messages": [],
                     "RegionName": "us-east-1",
                     "ZoneName": "us-east-1c",
+                    "ZoneId": "use1-az4",
                 },
                 {
                     "State": "available",
                     "Messages": [],
                     "RegionName": "us-east-1",
                     "ZoneName": "us-east-1d",
+                    "ZoneId": "use1-az3",
                 },
                 {
                     "State": "available",
                     "Messages": [],
                     "RegionName": "us-east-1",
                     "ZoneName": "us-east-1e",
+                    "ZoneId": "use1-az2",
                 },
                 {
                     "State": "available",
                     "Messages": [],
                     "RegionName": "us-east-1",
                     "ZoneName": "us-east-1f",
+                    "ZoneId": "use1-az1",
                 },
             ]
         }
@@ -88,36 +94,42 @@ class MockClient:
                     "Messages": [],
                     "RegionName": "us-east-1",
                     "ZoneName": "us-east-1a",
+                    "ZoneId": "use1-az6",
                 },
                 {
                     "State": "available",
                     "Messages": [],
                     "RegionName": "us-east-1",
                     "ZoneName": "us-east-1b",
+                    "ZoneId": "use1-az5",
                 },
                 {
                     "State": "available",
                     "Messages": [],
                     "RegionName": "us-east-1",
                     "ZoneName": "us-east-1c",
+                    "ZoneId": "use1-az4",
                 },
                 {
                     "State": "available",
                     "Messages": [],
                     "RegionName": "us-east-1",
                     "ZoneName": "us-east-1d",
+                    "ZoneId": "use1-az3",
                 },
                 {
                     "State": "available",
                     "Messages": [],
                     "RegionName": "us-east-1",
                     "ZoneName": "us-east-1e",
+                    "ZoneId": "use1-az2",
                 },
                 {
                     "State": "available",
                     "Messages": [],
                     "RegionName": "us-east-1",
                     "ZoneName": "us-east-1f",
+                    "ZoneId": "use1-az1",
                 },
             ]
         }
@@ -239,6 +251,31 @@ class TestParamGen(unittest.TestCase):
         pg = ParamGen(**self.class_kwargs)
         self.assertEqual(pg.regxfind(ParamGen.RE_COUNT, "$[taskcat_getaz_2]"), "2")
         self.assertEqual(pg.regxfind(ParamGen.RE_COUNT, "$[taskcat_genpass_8]"), "8")
+
+    def test_get_available_azs_with_excludes(self):
+        class_kwargs = {**self.class_kwargs, "az_excludes": {"use1-az6", "use1-az5"}}
+        pg = ParamGen(**class_kwargs)
+        pg._boto_client = MockClient
+        returned_azs = pg.get_available_azs(4)
+        returned_az_list = returned_azs.split(",")
+        test_criteria = [
+            # tuple (first_param, second_param, test_description)
+            (len(returned_az_list), 4, "Verifying we return 4 AZs"),
+            (len(set(returned_az_list)), 4, "Verifying we return 4 *unique* AZs"),
+            (
+                ("us-east-1a" not in returned_az_list),
+                True,
+                "Verifying us-east-1a is not returned.",
+            ),
+            (
+                ("us-east-1b" not in returned_az_list),
+                True,
+                "Verifying us-east-1b is not returned.",
+            ),
+        ]
+        for first_param, second_param, test_desc in test_criteria:
+            with self.subTest(test_desc):
+                self.assertEqual(first_param, second_param)
 
     def test_get_available_azs(self):
         pg = ParamGen(**self.class_kwargs)


### PR DESCRIPTION
- Adds support for ZoneName and ZoneId blacklisting via both project and test config-level options. This allows for fluctuations in ZoneId -> ZoneName mappings between accounts. 

Sample Config:
```
project:
  owner: quickstart-eng@amazon.com
  name: quickstart-linux-bastion
  az_blacklist:
    - us-east-1a
    - use1-az4
  regions:
    - ap-northeast-1
    - ap-northeast-2
    - ap-south-1
    - ap-southeast-1
    - ap-southeast-2
    - ca-central-1
    - eu-central-1
    - eu-west-1
    - eu-west-2
    - us-east-1
    - us-east-2
    - us-west-1
    - us-west-2
#    - sa-east-1
tests:
  amznlinuxhvm:
    parameter_input: linux-bastion-master-amznlinuxhvm.json
    template_file: linux-bastion-master.template
  centos7hvm:
    parameter_input: linux-bastion-master-centos7hvm.json
    template_file: linux-bastion-master.template
  us1404hvm:
    parameter_input: linux-bastion-master-us1404hvm.json
    template_file: linux-bastion-master.template
  us1604hvm:
    parameter_input: linux-bastion-master-us1604hvm.json
    template_file: linux-bastion-master.template
  sles15hvm:
    parameter_input: linux-bastion-master-sles15hvm.json
    template_file: linux-bastion-master.template
```

This is dependent on #35  and will need some flake/mypy advice.