### PR TITLE
fix build badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # taskcat
 
-[![Build Status](https://travis-ci.org/taskcat/taskcat-v9.svg?branch=master)](https://travis-ci.com/taskcat/taskcat-v9)
+[![Build Status](https://travis-ci.org/taskcat/taskcat-v9.svg?branch=master)](https://travis-ci.org/taskcat/taskcat-v9)
 [![Test Coverage](https://img.shields.io/codecov/c/github/taskcat/taskcat-v9.svg)](https://codecov.io/github/taskcat/taskcat-v9)
 
 ---


### PR DESCRIPTION
## Overview

build badge link was pointing to `.com` but should be `.org`

