### PR TITLE
Add __all__ to init.py

### DIFF
--- a/taskcat/__init__.py
+++ b/taskcat/__init__.py
@@ -5,3 +5,5 @@ from ._cfn.stack import Stack  # noqa: F401
 from ._cfn.template import Template  # noqa: F401
 from ._cli import main  # noqa: F401
 from ._config import Config  # noqa: F401
+
+__all__ = ["Stack", "Template", "Config", "main"]


### PR DESCRIPTION
## Overview

**Adds list of public module** 
`__all__` is used to identify all  public interfaces
pdoc will use docstrings to build corresponding documentation on release
## Testing/Steps taken to ensure quality
